### PR TITLE
Fix Ziggy frontend routes & allow Proxies by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ COPY --chown=nobody . .
 
 RUN composer install --optimize-autoloader --no-interaction --no-progress
 
-RUN php artisan ziggy:generate
-
 # Remove Composer Cache & Script since we do not need it any more
 USER root
 RUN rm -rf /root/.composer /usr/bin/composer

--- a/app/Http/Controllers/Api/ZiggyController.php
+++ b/app/Http/Controllers/Api/ZiggyController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Tightenco\Ziggy\Ziggy;
+use App\Http\Controllers\Controller;
+
+class ZiggyController extends Controller
+{
+    public function __invoke()
+    {
+        return response()->json(new Ziggy)
+            ->header('Cache-Control', 'max-age=360');
+    }
+}

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string|null
      */
-    protected $proxies;
+    protected $proxies = "*";
 
     /**
      * The headers that should be used to detect proxies.
@@ -20,7 +20,7 @@ class TrustProxies extends Middleware
      * @var int
      */
     protected $headers =
-        Request::HEADER_X_FORWARDED_FOR |
+    Request::HEADER_X_FORWARDED_FOR |
         Request::HEADER_X_FORWARDED_HOST |
         Request::HEADER_X_FORWARDED_PORT |
         Request::HEADER_X_FORWARDED_PROTO |

--- a/resources/js/api/conversation.ts
+++ b/resources/js/api/conversation.ts
@@ -8,7 +8,7 @@ export function callGetForm(
 ): Promise<AxiosResponse<PublicFormModel>> {
     return new Promise(async (resolve, reject) => {
         try {
-            const { route } = useRoutes();
+            const { route } = await useRoutes();
 
             const resolvedRoute = route("api.public.forms.show", {
                 uuid,
@@ -31,7 +31,7 @@ export function callGetFormStoryboard(
 ): Promise<AxiosResponse<FormStoryboard>> {
     return new Promise(async (resolve, reject) => {
         try {
-            const { route } = useRoutes();
+            const { route } = await useRoutes();
 
             const resolvedRoute = route("api.public.forms.storyboard", {
                 uuid,
@@ -55,7 +55,7 @@ export function callCreateFormSession(
 ): Promise<AxiosResponse<FormSessionModel>> {
     return new Promise(async (resolve, reject) => {
         try {
-            const { route } = useRoutes();
+            const { route } = await useRoutes();
 
             const resolvedRoute = route("api.public.forms.session.create", {
                 uuid,
@@ -82,7 +82,7 @@ export function callSubmitForm(
 ): Promise<AxiosResponse<null>> {
     return new Promise(async (resolve, reject) => {
         try {
-            const { route } = useRoutes();
+            const { route } = await useRoutes();
 
             const resolvedRoute = route("api.public.forms.submit", {
                 uuid,

--- a/resources/js/forms/classic.ts
+++ b/resources/js/forms/classic.ts
@@ -2,10 +2,8 @@ import "@css/embed.css";
 import { createApp, h, Suspense } from "vue";
 import { createPinia } from "pinia";
 import ClassicForm from "./classic/ClassicForm.vue";
-import { useRoutes } from "@/utils/useRoutes";
 
 const pinia = createPinia();
-const { route } = useRoutes();
 
 const formId = document.currentScript?.getAttribute("data-form");
 let mountElement: Element | string | null = document.querySelector(
@@ -39,5 +37,4 @@ createApp({
     },
 })
     .use(pinia)
-    .mixin({ methods: { route } })
     .mount(mountElement);

--- a/resources/js/utils/useRoutes.ts
+++ b/resources/js/utils/useRoutes.ts
@@ -2,15 +2,17 @@
 // @ts-ignore
 import route from "ziggy";
 import { RouteParamsWithQueryOverload } from "ziggy-js";
-import { Ziggy } from "@/ziggy";
 
-export function useRoutes(): {
+export async function useRoutes(): Promise<{
     route: (
         name?: string,
         params?: RouteParamsWithQueryOverload,
         absolute?: boolean
     ) => string | undefined;
-} {
+}> {
+    const response = await fetch("/api/routes");
+    const Ziggy = await response.json();
+
     const routeWrapper = (
         name?: string,
         params?: RouteParamsWithQueryOverload,

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tightenco\Ziggy\Ziggy;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
@@ -39,6 +40,8 @@ $router->get('public/forms/{form}/storyboard', GetFormStoryboardController::clas
 $router->post('public/forms/{form}/session', CreateFormSessionController::class)->name('api.public.forms.session.create');
 $router->get('public/forms/{form}', ShowFormController::class)->name('api.public.forms.show');
 $router->post('public/forms/{form}', FormSubmitController::class)->name('api.public.forms.submit');
+
+$router->get('routes', fn () => response()->json(new Ziggy)->header('Cache-Control', 'max-age=360'));
 
 $router->middleware(['auth:sanctum'])->group(function (Router $router) {
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,5 @@
 <?php
 
-use Tightenco\Ziggy\Ziggy;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
@@ -20,6 +19,7 @@ use App\Http\Controllers\Api\FormTemplateExportController;
 use App\Http\Controllers\Api\FormTemplateImportController;
 use App\Http\Controllers\Api\FormBlockInteractionController;
 use App\Http\Controllers\Api\FormBlockInteractionSequenceController;
+use App\Http\Controllers\Api\ZiggyController;
 
 /*
 |--------------------------------------------------------------------------
@@ -41,7 +41,7 @@ $router->post('public/forms/{form}/session', CreateFormSessionController::class)
 $router->get('public/forms/{form}', ShowFormController::class)->name('api.public.forms.show');
 $router->post('public/forms/{form}', FormSubmitController::class)->name('api.public.forms.submit');
 
-$router->get('routes', fn () => response()->json(new Ziggy)->header('Cache-Control', 'max-age=360'));
+$router->get('routes', ZiggyController::class);
 
 $router->middleware(['auth:sanctum'])->group(function (Router $router) {
 


### PR DESCRIPTION
The Ziggy routes file has been generated during the image build. Since it is relying on the APP_URL env, which might be set later to something different, when running the container, it failed in cases with different URL settings.

This is the first fix that pulls the route information via API endpoint from the currently running instance. In this case, we should always get the correct routes file, even if the APP_URL setting is going to change.