### PR TITLE
Add support for HTTPS behind a reverse Proxy

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -36,5 +37,10 @@ class AppServiceProvider extends ServiceProvider
                 return $this->where(DB::raw('BINARY `uuid`'), $id);
             }
         });
+
+        // Force HTTPS if requested
+        if (env('USE_HTTPS', false)) {
+            URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
This PR forces the use of HTTPS if the new env option `USE_HTTPS` is set to `true`, This doesn't add support for Lets Encrypt or anything fancy but it will allow an nginx, Caddy, Traefic or other reverse proxy to manage the SSL / TLS cert and not result in pages not loading.