### PR TITLE
Adds native input types to basic input fields with validation

### DIFF
--- a/resources/js/forms/classic/interactions/InputAction.vue
+++ b/resources/js/forms/classic/interactions/InputAction.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <label class="sr-only block" :for="action.id"> {{ action.label }}</label>
+    <label class="sr-only block" :for="action.id">{{ action.label }}</label>
     <input
-      type="text"
+      :type="nativeInputType"
       class="block w-full max-w-xs rounded border border-grey-300 bg-white px-3 py-2 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
       :name="block.id"
       :id="action.id"
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ComputedRef, inject, onMounted, ref } from "vue";
+import { computed, ComputedRef, inject, onMounted, ref } from "vue";
 import { useConversation } from "@/stores/conversation";
 
 const store = useConversation();
@@ -31,6 +31,28 @@ const disableFocus: ComputedRef<boolean> | undefined = inject("disableFocus");
 const storeValue = (store.currentPayload as FormBlockInteractionPayload)
   ?.payload;
 const inputElement = ref<HTMLInputElement | null>(null);
+
+// get the input element type based on the action type
+const nativeInputType = computed(() => {
+  const action: FormBlockType = props.block.type;
+
+  switch (action) {
+    case "input-number":
+      return "number";
+
+    case "input-email":
+      return "email";
+
+    case "input-link":
+      return "url";
+
+    case "input-phone":
+      return "tel";
+
+    default:
+      return "text";
+  }
+});
 
 onMounted(() => {
   if (!disableFocus?.value) {


### PR DESCRIPTION
Before, we had all inputs like this:

`<input type="text" />`

This PR changes the input type based on the selected block type. For example, if we have an input with email validation we now use  `<input type="email" />`