### PR TITLE
Add beforeUnloadEvent to prevent leaving form without saving

### DIFF
--- a/resources/js/forms/classic/ClassicForm.vue
+++ b/resources/js/forms/classic/ClassicForm.vue
@@ -43,7 +43,9 @@ import Navigator from "@/forms/classic/layout/Navigator.vue";
 import FooterNavigation from "@/forms/classic/layout/FooterNavigation.vue";
 import { useConversation } from "@/stores/conversation";
 import { useThemableColor } from "@/utils/useThemableColor";
+import { useBeforeUnload } from "@/utils/useBeforeUnload";
 import { computed, onMounted, provide, ref } from "vue";
+import { storeToRefs } from "pinia";
 
 const props = defineProps<{
   settings: PublicFormModel;
@@ -75,8 +77,12 @@ new URLSearchParams(window.location.search).forEach((value, key) => {
 const store = useConversation();
 await store.initForm(props.settings, params);
 
+const { hasUnsavedPayload } = storeToRefs(store);
+
 onMounted(() => {
   isLoading.value = false;
+
+  useBeforeUnload(hasUnsavedPayload);
 });
 
 const primaryColor = useThemableColor(store.form?.brand_color ?? "#1f2937");

--- a/resources/js/stores/conversation.ts
+++ b/resources/js/stores/conversation.ts
@@ -81,7 +81,8 @@ export const useConversation = defineStore("form", {
          */
         hasUnsavedPayload(state): Ref<boolean> {
             return ref(
-                state.payload &&
+                !state.isSubmitted &&
+                    state.payload &&
                     Object.keys(state.payload).length > 0 &&
                     state.current > 0
             );

--- a/resources/js/stores/conversation.ts
+++ b/resources/js/stores/conversation.ts
@@ -5,6 +5,7 @@ import {
     callSubmitForm,
     callGetForm,
 } from "@/api/conversation";
+import { Ref, ref } from "vue";
 
 type ConversationStore = {
     form?: PublicFormModel;
@@ -68,6 +69,22 @@ export const useConversation = defineStore("form", {
             }
 
             return null;
+        },
+
+        /**
+         * This getter determines if the user has entered content that is not saved yet.
+         * For now that is the case once a user typed something in and is at least
+         * on a second block.
+         *
+         * @param state
+         * @returns true | false
+         */
+        hasUnsavedPayload(state): Ref<boolean> {
+            return ref(
+                state.payload &&
+                    Object.keys(state.payload).length > 0 &&
+                    state.current > 0
+            );
         },
 
         currentBlockIdentifier(): string | null {

--- a/resources/js/utils/useBeforeUnload.ts
+++ b/resources/js/utils/useBeforeUnload.ts
@@ -11,15 +11,11 @@ export function useBeforeUnload(
         return confirmationMessage;
     };
 
-    watch(
-        isUnloadActive,
-        (isActive: Ref<boolean>) => {
-            if (isActive.value) {
-                window.addEventListener("beforeunload", onBeforeUnload);
-            } else {
-                window.removeEventListener("beforeunload", onBeforeUnload);
-            }
-        },
-        { immediate: true }
-    );
+    watch(isUnloadActive, (isActive: Ref<boolean>) => {
+        if (isActive.value) {
+            window.addEventListener("beforeunload", onBeforeUnload);
+        } else {
+            window.removeEventListener("beforeunload", onBeforeUnload);
+        }
+    });
 }

--- a/resources/js/utils/useBeforeUnload.ts
+++ b/resources/js/utils/useBeforeUnload.ts
@@ -1,0 +1,25 @@
+import { ref, Ref, watch } from "vue";
+
+export function useBeforeUnload(
+    isUnloadActive: Ref<boolean> = ref(true),
+    confirmationMessage = "Your changes may not be saved."
+): void {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+        // this line is needed for cross browser compatibility
+        (event || window.event).returnValue = confirmationMessage;
+
+        return confirmationMessage;
+    };
+
+    watch(
+        isUnloadActive,
+        (isActive: Ref<boolean>) => {
+            if (isActive.value) {
+                window.addEventListener("beforeunload", onBeforeUnload);
+            } else {
+                window.removeEventListener("beforeunload", onBeforeUnload);
+            }
+        },
+        { immediate: true }
+    );
+}


### PR DESCRIPTION
I think it should be somehow a best practice to prevent the case where a user accidentally loses his input data when he has not saved the form yet.

One way to do that is to prevent navigating to another page if the form is unsaved.