### PR TITLE
Add simple filter options for the forms dashboard

### DIFF
--- a/app/Http/Controllers/Api/FormController.php
+++ b/app/Http/Controllers/Api/FormController.php
@@ -10,7 +10,14 @@ class FormController extends Controller
 {
     public function index(Request $request)
     {
-        $forms = $request->user()->forms()->get();
+        $request->validate([
+            'filter' => 'in:published,unpublished,trashed',
+        ]);
+
+        $forms = $request->user()
+            ->forms()
+            ->withFilter($request->filter ?? null)
+            ->get();
 
         return response()->json($forms);
     }

--- a/app/Http/Controllers/Api/TrashedFormController.php
+++ b/app/Http/Controllers/Api/TrashedFormController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class TrashedFormController extends Controller
+{
+    public function delete(Request $request, $form)
+    {
+        $formObject = $request->user()->forms()->withTrashed()->find($form);
+
+        dd($form, $formObject);
+    }
+
+    public function restore(Request $request)
+    {
+
+    }
+}

--- a/app/Http/Controllers/Api/TrashedFormController.php
+++ b/app/Http/Controllers/Api/TrashedFormController.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Models\Form;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 
 class TrashedFormController extends Controller
 {
@@ -16,7 +15,7 @@ class TrashedFormController extends Controller
             ->where('uuid', $form)
             ->firstOrFail();
 
-        if (!$model->trashed()) {
+        if (! $model->trashed()) {
             return abort(422, 'You need to put the form into trash before deleting it permanently.');
         }
 

--- a/app/Http/Controllers/Api/TrashedFormController.php
+++ b/app/Http/Controllers/Api/TrashedFormController.php
@@ -2,20 +2,41 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller;
+use App\Models\Form;
 use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
 
 class TrashedFormController extends Controller
 {
     public function delete(Request $request, $form)
     {
-        $formObject = $request->user()->forms()->withTrashed()->find($form);
+        $model = $request->user()
+            ->forms()
+            ->withTrashed()
+            ->where('uuid', $form)
+            ->firstOrFail();
 
-        dd($form, $formObject);
+        if (!$model->trashed()) {
+            return abort(422, 'You need to put the form into trash before deleting it permanently.');
+        }
+
+        $model->forceDelete();
+
+        return response()->json([], 200);
     }
 
-    public function restore(Request $request)
+    public function restore(Request $request, $form)
     {
+        $model = $request->user()
+            ->forms()
+            ->withTrashed()
+            ->where('uuid', $form)
+            ->firstOrFail();
 
+        if ($model->trashed()) {
+            $model->restore();
+        }
+
+        return response()->json($model);
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -9,7 +9,11 @@ class DashboardController extends Controller
 {
     public function show(Request $request)
     {
-        $forms = $request->user()->forms;
+        $request->validate([
+            'filter' => 'in:published,unpublished,trashed',
+        ]);
+
+        $forms = $request->user()->forms()->withFilter($request->filter ?? null)->get();
 
         return Inertia::render('Dashboard', [
             'initialForms' => $forms,

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -12,7 +12,7 @@ class DashboardController extends Controller
         $forms = $request->user()->forms;
 
         return Inertia::render('Dashboard', [
-            'forms' => $forms,
+            'initialForms' => $forms,
         ]);
     }
 }

--- a/app/Http/Controllers/FormSubmissionsExportController.php
+++ b/app/Http/Controllers/FormSubmissionsExportController.php
@@ -62,7 +62,7 @@ class FormSubmissionsExportController extends Controller
             $out = fopen('php://output', 'w');
 
             // Add BOM for UTF-8 to help software like Excel to correctly identify encoding
-            fwrite($out, chr(0xEF) . chr(0xBB) . chr(0xBF));
+            fwrite($out, chr(0xEF).chr(0xBB).chr(0xBF));
 
             fputcsv($out, array_keys($exportFormatted[0]));
 

--- a/app/Http/Resources/FormSessionResponseResource.php
+++ b/app/Http/Resources/FormSessionResponseResource.php
@@ -28,7 +28,7 @@ class FormSessionResponseResource extends JsonResource
                 'name' => '',
                 'value' => '',
                 'original' => '',
-                'message' => ''
+                'message' => '',
             ];
         }
     }
@@ -50,7 +50,7 @@ class FormSessionResponseResource extends JsonResource
         if ($this->formBlock->type === FormBlockType::consent) {
             $accepted = $value['accepted'] ? 'yes' : 'no';
 
-            return $value['consent'] . ': ' . $accepted;
+            return $value['consent'].': '.$accepted;
         }
 
         if ($this->formBlock->type === FormBlockType::rating || $this->formBlock->type === FormBlockType::scale) {

--- a/app/Http/Resources/PublicFormResource.php
+++ b/app/Http/Resources/PublicFormResource.php
@@ -42,6 +42,7 @@ class PublicFormResource extends JsonResource
             'show_social_links' => $this->show_social_links,
             'show_form_progress' => $this->show_form_progress,
             'is_published' => $this->is_published,
+            'is_trashed' => $this->is_trashed,
             'avatar' => $this->avatar,
             'background' => $this->background,
             'company_name' => $this->company_name,

--- a/app/Listeners/FormSessionNotificationListener.php
+++ b/app/Listeners/FormSessionNotificationListener.php
@@ -2,10 +2,8 @@
 
 namespace App\Listeners;
 
-use Illuminate\Support\Facades\Mail;
 use App\Mail\FormSubmissionNotification;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Mail;
 
 class FormSessionNotificationListener
 {

--- a/app/Mail/FormSubmissionNotification.php
+++ b/app/Mail/FormSubmissionNotification.php
@@ -2,14 +2,14 @@
 
 namespace App\Mail;
 
+use App\Http\Resources\FormSessionResource;
 use App\Models\FormSession;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Mail\Mailables\Envelope;
-use App\Http\Resources\FormSessionResource;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\SerializesModels;
 
 class FormSubmissionNotification extends Mailable implements ShouldQueue
 {
@@ -17,6 +17,7 @@ class FormSubmissionNotification extends Mailable implements ShouldQueue
     use SerializesModels;
 
     public $session;
+
     public $form;
 
     /**

--- a/app/Models/Form.php
+++ b/app/Models/Form.php
@@ -65,6 +65,7 @@ class Form extends BaseModel
         'completed_sessions',
         'completion_rate',
         'is_published',
+        'is_trashed',
         'initials',
     ];
 
@@ -207,6 +208,11 @@ class Form extends BaseModel
         }
 
         return false;
+    }
+
+    public function getIsTrashedAttribute()
+    {
+        return $this->deleted_at && $this->deleted_at->isPast();
     }
 
     public function getIsPublishedAttribute()

--- a/app/Models/Form.php
+++ b/app/Models/Form.php
@@ -7,6 +7,7 @@ use App\Http\Resources\PublicFormBlockResource;
 use App\Http\Resources\PublicFormResource;
 use App\Models\Traits\TemplateExportsAndImports;
 use Hashids\Hashids;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -145,6 +146,16 @@ class Form extends BaseModel
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function scopeWithFilter(Builder $builder, ?string $filter)
+    {
+        return match ($filter) {
+            'published' => $builder->published(),
+            'unpublished' => $builder->whereNull('published_at')->orWhereDate('published_at', '>', Carbon::now()),
+            'trashed' => $builder->withTrashed()->whereNotNull('deleted_at'),
+            default => $builder,
+        };
     }
 
     public function route()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -16,7 +19,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->bind(
+            HttpClientInterface::class,
+            function ($app) {
+                return new NoPrivateNetworkHttpClient(HttpClient::create());
+            }
+        );
     }
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -3,14 +3,14 @@
 namespace App\Providers;
 
 use App\Events\FormPublished;
-use App\Listeners\CreatePreviewImage;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Auth\Events\Registered;
 use App\Events\FormSessionCompletedEvent;
-use App\Listeners\FormSubmitWebhookListener;
+use App\Listeners\CreatePreviewImage;
 use App\Listeners\FormSessionNotificationListener;
+use App\Listeners\FormSubmitWebhookListener;
+use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Event;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -30,7 +30,7 @@ class EventServiceProvider extends ServiceProvider
 
         FormSessionCompletedEvent::class => [
             FormSubmitWebhookListener::class,
-            FormSessionNotificationListener::class
+            FormSessionNotificationListener::class,
         ],
     ];
 

--- a/database/factories/FormFactory.php
+++ b/database/factories/FormFactory.php
@@ -42,4 +42,13 @@ class FormFactory extends Factory
             ];
         });
     }
+
+    public function deleted()
+    {
+        return $this->state(function ($attributes) {
+            return [
+                'deleted_at' => Carbon::now(),
+            ];
+        });
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.5.0",
             "license": "GNU Affero General Public License v3.0",
             "dependencies": {
-                "@deck9/ui": "^0.12.12",
+                "@deck9/ui": "^0.12.13",
                 "@headlessui/vue": "^1.7.14",
                 "@highlightjs/vue-plugin": "^2.1.0",
                 "@inertiajs/inertia": "^0.11.1",
@@ -219,9 +219,9 @@
             }
         },
         "node_modules/@deck9/ui": {
-            "version": "0.12.12",
-            "resolved": "https://registry.npmjs.org/@deck9/ui/-/ui-0.12.12.tgz",
-            "integrity": "sha512-ezkiYrAmOmxSJyP9aU+dADkLA2LdZOtC8GQj+cb0EqG3Y+NUC7ZgfzMRJPfmvn3ZNbUTDJyzmJkKLq0cBngW9A==",
+            "version": "0.12.13",
+            "resolved": "https://registry.npmjs.org/@deck9/ui/-/ui-0.12.13.tgz",
+            "integrity": "sha512-lR9GElzTCL1RheCSsRlKDREKjMjXOuVIc6TIQITcDp3LCg8nVGodW1ZCcaAhLotDywHPcpA0VU9urxnGjP/kLw==",
             "dependencies": {
                 "@deck9/tailwindcss-recursive-font-helper": "^1.0.1",
                 "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "vitest": "^0.31.4"
     },
     "dependencies": {
-        "@deck9/ui": "^0.12.12",
+        "@deck9/ui": "^0.12.13",
         "@headlessui/vue": "^1.7.14",
         "@highlightjs/vue-plugin": "^2.1.0",
         "@inertiajs/inertia": "^0.11.1",

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -10,45 +10,9 @@
               <h2 class="text-xl font-bold leading-8 text-grey-900">
                 Your Forms
               </h2>
-              <Label class="ml-2" v-show="filter" color="grey">
-                {{ filter }}
-                <button @click="filter = null"><D9Icon name="close" /></button>
-              </Label>
             </div>
-            <div>
-              <Popover class="relative inline-block">
-                <PopoverButton
-                  class="relative mr-2 inline-flex items-center rounded-lg border-transparent bg-grey-100 px-5 py-2 text-sm font-medium leading-4 text-blue-600 ring-blue-300 ring-offset-2 transition duration-150 ease-in-out hover:bg-blue-100 hover:text-blue-700 focus:outline-none focus:ring active:bg-grey-100 active:ring dark:ring-offset-grey-900"
-                >
-                  Filter
-                  <D9Icon class="-mr-1 ml-3 text-blue-600" name="filter" />
-                </PopoverButton>
-                <PopoverPanel
-                  class="absolute z-10 flex flex-col items-stretch rounded bg-grey-50 px-1 py-2 text-grey-700 shadow-lg"
-                >
-                  <button
-                    class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
-                    type="button"
-                    @click="filter = 'published'"
-                  >
-                    Published
-                  </button>
-                  <button
-                    class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
-                    type="button"
-                    @click="filter = 'unpublished'"
-                  >
-                    Unpublished
-                  </button>
-                  <button
-                    class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
-                    type="button"
-                    @click="filter = 'trashed'"
-                  >
-                    Trashed
-                  </button>
-                </PopoverPanel>
-              </Popover>
+            <div class="flex">
+              <FilterControl :filter="filter" @changeFilter="changeFilter" />
               <CreateFormButton />
             </div>
           </div>
@@ -70,6 +34,13 @@
             </p>
           </div>
 
+          <div
+            class="w-full rounded bg-white p-16 text-center"
+            v-else-if="isLoading"
+          >
+            <D9Spinner />
+          </div>
+
           <div v-else>
             <FormListItem :form="form" :key="form.id" v-for="form in forms" />
           </div>
@@ -85,12 +56,11 @@ import AppLayout from "@/Layouts/AppLayout.vue";
 import FormListItem from "@/components/Dashboard/FormListItem.vue";
 import UpdatesContainer from "@/components/Dashboard/UpdatesContainer.vue";
 import CreateFormButton from "@/components/Dashboard/CreateFormButton.vue";
-import { Popover, PopoverButton, PopoverPanel } from "@headlessui/vue";
-import Label from "@/components/Label.vue";
+import FilterControl from "@/components/Dashboard/FilterControl.vue";
 
-import { D9Icon } from "@deck9/ui";
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import { callListForms } from "@/api/forms";
+import { D9Spinner } from "@deck9/ui";
 
 const props = withDefaults(
   defineProps<{
@@ -101,12 +71,20 @@ const props = withDefaults(
   }
 );
 
+const isLoading = ref(false);
 const forms = ref<Array<FormModel>>(props.initialForms);
 const filter = ref<"published" | "unpublished" | "trashed" | null>(null);
 
-watch(filter, async (newFilter) => {
-  const response = await callListForms(newFilter);
-
-  forms.value = response.data;
-});
+const changeFilter = async (setting: FilterSetting) => {
+  isLoading.value = true;
+  try {
+    const response = await callListForms(setting);
+    filter.value = setting;
+    forms.value = response.data;
+  } catch (e) {
+    console.warn(e);
+  } finally {
+    isLoading.value = false;
+  }
+};
 </script>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -6,10 +6,51 @@
       >
         <div class="col-span-12 lg:col-span-8">
           <div class="relative mb-6 flex items-center justify-between">
-            <h2 class="text-xl font-bold leading-8 text-grey-900">
-              Your Forms
-            </h2>
-            <CreateFormButton />
+            <div class="flex items-center">
+              <h2 class="text-xl font-bold leading-8 text-grey-900">
+                Your Forms
+              </h2>
+              <Label class="ml-2" v-show="filter" color="grey">
+                {{ filter }}
+                <button @click="filter = null"><D9Icon name="close" /></button>
+              </Label>
+            </div>
+            <div>
+              <Popover class="relative inline-block">
+                <PopoverButton
+                  class="relative mr-2 inline-flex items-center rounded-lg border-transparent bg-grey-100 px-5 py-2 text-sm font-medium leading-4 text-blue-600 ring-blue-300 ring-offset-2 transition duration-150 ease-in-out hover:bg-blue-100 hover:text-blue-700 focus:outline-none focus:ring active:bg-grey-100 active:ring dark:ring-offset-grey-900"
+                >
+                  Filter
+                  <D9Icon class="-mr-1 ml-3 text-blue-600" name="filter" />
+                </PopoverButton>
+                <PopoverPanel
+                  class="absolute z-10 flex flex-col items-stretch rounded bg-grey-50 px-1 py-2 text-grey-700 shadow-lg"
+                >
+                  <button
+                    class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
+                    type="button"
+                    @click="filter = 'published'"
+                  >
+                    Published
+                  </button>
+                  <button
+                    class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
+                    type="button"
+                    @click="filter = 'unpublished'"
+                  >
+                    Unpublished
+                  </button>
+                  <button
+                    class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
+                    type="button"
+                    @click="filter = 'trashed'"
+                  >
+                    Trashed
+                  </button>
+                </PopoverPanel>
+              </Popover>
+              <CreateFormButton />
+            </div>
           </div>
 
           <div
@@ -44,14 +85,28 @@ import AppLayout from "@/Layouts/AppLayout.vue";
 import FormListItem from "@/components/Dashboard/FormListItem.vue";
 import UpdatesContainer from "@/components/Dashboard/UpdatesContainer.vue";
 import CreateFormButton from "@/components/Dashboard/CreateFormButton.vue";
-// import { withDefaults } from "vue";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/vue";
+import Label from "@/components/Label.vue";
 
-withDefaults(
+import { D9Icon } from "@deck9/ui";
+import { ref, watch } from "vue";
+import { callListForms } from "@/api/forms";
+
+const props = withDefaults(
   defineProps<{
-    forms: Array<FormModel>;
+    initialForms: Array<FormModel>;
   }>(),
   {
-    forms: () => [],
+    initialForms: () => [],
   }
 );
+
+const forms = ref<Array<FormModel>>(props.initialForms);
+const filter = ref<"published" | "unpublished" | "trashed" | null>(null);
+
+watch(filter, async (newFilter) => {
+  const response = await callListForms(newFilter);
+
+  forms.value = response.data;
+});
 </script>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -61,6 +61,9 @@ import FilterControl from "@/components/Dashboard/FilterControl.vue";
 import { ref } from "vue";
 import { callListForms } from "@/api/forms";
 import { D9Spinner } from "@deck9/ui";
+import { useUrlSearchParams } from "@vueuse/core";
+
+const params = useUrlSearchParams("history");
 
 const props = withDefaults(
   defineProps<{
@@ -81,10 +84,20 @@ const changeFilter = async (setting: FilterSetting) => {
     const response = await callListForms(setting);
     filter.value = setting;
     forms.value = response.data;
+
+    if (setting) {
+      params.filter = setting;
+    } else {
+      delete params.filter;
+    }
   } catch (e) {
     console.warn(e);
   } finally {
     isLoading.value = false;
   }
 };
+
+if (params.filter) {
+  filter.value = params.filter as FilterSetting;
+}
 </script>

--- a/resources/js/api/forms.ts
+++ b/resources/js/api/forms.ts
@@ -325,3 +325,35 @@ export function callDuplicateForm(
         }
     });
 }
+
+export function callDeleteForeverForm(form: FormModel): Promise<AxiosResponse> {
+    return new Promise(async (resolve, reject) => {
+        try {
+            const response = await handler.delete(
+                window.route("api.forms.trashed.delete", {
+                    form: form.uuid,
+                })
+            );
+
+            resolve(response as AxiosResponse);
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+export function callRestoreForm(form: FormModel): Promise<AxiosResponse> {
+    return new Promise(async (resolve, reject) => {
+        try {
+            const response = await handler.post(
+                window.route("api.forms.trashed.restore", {
+                    form: form.uuid,
+                })
+            );
+
+            resolve(response as AxiosResponse);
+        } catch (error) {
+            reject(error);
+        }
+    });
+}

--- a/resources/js/api/forms.ts
+++ b/resources/js/api/forms.ts
@@ -2,6 +2,25 @@
 import { AxiosResponse } from "axios";
 import handler from "./handler";
 
+export function callListForms(
+    filter: string | null = null
+): Promise<AxiosResponse<FormModel[]>> {
+    return new Promise(async (resolve, reject) => {
+        try {
+            const response = await handler.get(
+                window.route("api.forms.index"),
+                {
+                    params: { filter },
+                }
+            );
+
+            resolve(response as AxiosResponse<FormModel[]>);
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
 export function callCreateForm(): Promise<AxiosResponse<FormModel>> {
     return new Promise(async (resolve, reject) => {
         try {

--- a/resources/js/components/Dashboard/FilterControl.vue
+++ b/resources/js/components/Dashboard/FilterControl.vue
@@ -1,0 +1,63 @@
+<template>
+  <div>
+    <Label class="mr-2" v-show="filter" color="grey">
+      {{ filter }}
+      <button @click="emit('changeFilter', null)">
+        <D9Icon name="close" />
+      </button>
+    </Label>
+    <Popover class="relative inline-block">
+      <PopoverButton
+        class="relative mr-2 inline-flex items-center rounded-lg border-transparent bg-grey-100 px-5 py-2 text-sm font-medium leading-4 text-blue-600 ring-blue-300 ring-offset-2 transition duration-150 ease-in-out hover:bg-blue-100 hover:text-blue-700 focus:outline-none focus:ring active:bg-grey-100 active:ring dark:ring-offset-grey-900"
+      >
+        Filter
+        <D9Icon class="-mr-1 ml-3 text-blue-600" name="filter" />
+      </PopoverButton>
+      <PopoverPanel
+        v-slot="{ close }"
+        class="absolute z-10 flex flex-col items-stretch rounded bg-grey-50 px-1 py-2 text-grey-700 shadow-lg"
+      >
+        <button
+          class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
+          type="button"
+          @click="clickFilter('published', close)"
+        >
+          Published
+        </button>
+        <button
+          class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
+          type="button"
+          @click="clickFilter('unpublished', close)"
+        >
+          Unpublished
+        </button>
+        <button
+          class="block rounded px-3 py-1 text-left font-medium hover:bg-grey-200"
+          type="button"
+          @click="clickFilter('trashed', close)"
+        >
+          Trashed
+        </button>
+      </PopoverPanel>
+    </Popover>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { D9Icon } from "@deck9/ui";
+import Label from "@/components/Label.vue";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/vue";
+
+defineProps<{
+  filter: FilterSetting;
+}>();
+
+const emit = defineEmits<{
+  (event: "changeFilter", setting: FilterSetting): void;
+}>();
+
+const clickFilter = (setting: FilterSetting, close: any) => {
+  emit("changeFilter", setting);
+  close();
+};
+</script>

--- a/resources/js/components/Dashboard/FormListItem.vue
+++ b/resources/js/components/Dashboard/FormListItem.vue
@@ -150,10 +150,14 @@
 </template>
 
 <script setup lang="ts">
-import { D9Icon, D9Menu, D9MenuLink, D9Button } from "@deck9/ui";
+import { D9Icon, D9Menu, D9MenuLink } from "@deck9/ui";
 import { ref } from "vue";
 import { onClickOutside } from "@vueuse/core";
-import { callDuplicateForm } from "@/api/forms";
+import {
+  callDeleteForeverForm,
+  callDuplicateForm,
+  callRestoreForm,
+} from "@/api/forms";
 
 const props = defineProps<{
   form: FormModel;
@@ -191,13 +195,21 @@ const duplicateForm = async () => {
   });
 };
 
-const restoreForm = () => {
-  window.alert("restore form now");
+const restoreForm = async () => {
+  const restored = await callRestoreForm(props.form);
+
+  window.location.href = window.route("forms.edit", {
+    uuid: restored.data.uuid,
+  });
 };
 
-const deleteForever = () => {
+const deleteForever = async () => {
   window.confirm(
     "Are you sure you want to delete your form permanently. This action cannot be undone."
   );
+
+  await callDeleteForeverForm(props.form);
+
+  window.location.reload();
 };
 </script>

--- a/resources/js/components/Dashboard/FormListItem.vue
+++ b/resources/js/components/Dashboard/FormListItem.vue
@@ -99,6 +99,14 @@
           label="Settings"
         />
         <D9MenuLink
+          v-if="!form.is_published && !form.is_trashed"
+          as="button"
+          type="button"
+          class="block w-full text-left"
+          label="Delete Form"
+          @click="deleteForm"
+        />
+        <D9MenuLink
           as="button"
           type="button"
           class="block w-full text-left"
@@ -155,6 +163,7 @@ import { ref } from "vue";
 import { onClickOutside } from "@vueuse/core";
 import {
   callDeleteForeverForm,
+  callDeleteForm,
   callDuplicateForm,
   callRestoreForm,
 } from "@/api/forms";
@@ -201,6 +210,16 @@ const restoreForm = async () => {
   window.location.href = window.route("forms.edit", {
     uuid: restored.data.uuid,
   });
+};
+
+const deleteForm = async () => {
+  window.confirm(
+    "Are you sure you want to delete your form?"
+  );
+
+  await callDeleteForm(props.form);
+
+  window.location.reload();
 };
 
 const deleteForever = async () => {

--- a/resources/js/components/Dashboard/FormListItem.vue
+++ b/resources/js/components/Dashboard/FormListItem.vue
@@ -103,6 +103,22 @@
           as="button"
           type="button"
           class="block w-full text-left"
+          label="Publish Form"
+          @click="publishForm"
+        />
+        <D9MenuLink
+          v-if="form.is_published && !form.is_trashed"
+          as="button"
+          type="button"
+          class="block w-full text-left"
+          label="Unpublish Form"
+          @click="unpublishForm"
+        />
+        <D9MenuLink
+          v-if="!form.is_published && !form.is_trashed"
+          as="button"
+          type="button"
+          class="block w-full text-left"
           label="Delete Form"
           @click="deleteForm"
         />
@@ -165,7 +181,9 @@ import {
   callDeleteForeverForm,
   callDeleteForm,
   callDuplicateForm,
+  callPublishForm,
   callRestoreForm,
+  callUnpublishForm,
 } from "@/api/forms";
 
 const props = defineProps<{
@@ -202,6 +220,18 @@ const duplicateForm = async () => {
   window.location.href = window.route("forms.edit", {
     uuid: newFormResponse.data.uuid,
   });
+};
+
+const publishForm = async () => {
+  await callPublishForm(props.form);
+
+  window.location.reload();
+};
+
+const unpublishForm = async () => {
+  await callUnpublishForm(props.form)
+
+  window.location.reload();
 };
 
 const restoreForm = async () => {

--- a/resources/js/components/Dashboard/FormListItem.vue
+++ b/resources/js/components/Dashboard/FormListItem.vue
@@ -25,17 +25,25 @@
           </a>
         </h3>
 
-        <div v-if="form.is_published" class="flex items-center">
-          <span
-            class="mr-1 inline-block h-3 w-3 rounded-full bg-green-500"
-          ></span>
-          <span class="text-xs text-grey-500">Published</span>
-        </div>
-        <div v-else class="flex items-center">
-          <span
-            class="mr-1 inline-block h-3 w-3 rounded-full bg-grey-200"
-          ></span>
-          <span class="text-xs text-grey-500">Unpublished</span>
+        <div class="flex items-center">
+          <template v-if="form.is_trashed">
+            <span
+              class="mr-1 inline-block h-3 w-3 rounded-full bg-red-500"
+            ></span>
+            <span class="text-xs text-grey-500">Deleted</span>
+          </template>
+          <template v-else-if="form.is_published">
+            <span
+              class="mr-1 inline-block h-3 w-3 rounded-full bg-green-500"
+            ></span>
+            <span class="text-xs text-grey-500">Published</span>
+          </template>
+          <template v-else>
+            <span
+              class="mr-1 inline-block h-3 w-3 rounded-full bg-grey-200"
+            ></span>
+            <span class="text-xs text-grey-500">Unpublished</span>
+          </template>
         </div>
       </div>
     </div>

--- a/resources/js/components/Dashboard/FormListItem.vue
+++ b/resources/js/components/Dashboard/FormListItem.vue
@@ -17,12 +17,13 @@
       </div>
       <div class="ml-6 overflow-hidden">
         <h3 class="mb-1 truncate text-base font-bold">
-          <a
+          <component
+            :is="form.is_trashed ? 'span' : 'a'"
             class="hover:text-blue-600"
             :href="route('forms.edit', { uuid: form.uuid })"
           >
             {{ form.name }}
-          </a>
+          </component>
         </h3>
 
         <div class="flex items-center">
@@ -61,11 +62,12 @@
         <div class="mt-1 text-xs text-grey-500">Completion Rate</div>
       </div>
     </div>
-    <div class="flex w-1/5 justify-end">
+    <div class="flex w-1/5 items-center justify-end">
       <D9Menu
         class="flex items-center"
         position="left"
         use-portal
+        v-if="!form.is_trashed"
         @click="setActive"
       >
         <template #button>
@@ -104,7 +106,40 @@
           @click="duplicateForm"
         />
       </D9Menu>
+      <D9Menu
+        class="flex items-center"
+        position="left"
+        use-portal
+        v-else
+        @click="setActive"
+      >
+        <template #button>
+          <D9Icon
+            :class="[
+              'relative px-4 text-grey-600 transition-all duration-150 group-hover:opacity-100',
+              isActive ? ' opacity-100' : '  opacity-0',
+            ]"
+            name="cog"
+          />
+        </template>
+
+        <D9MenuLink
+          as="button"
+          type="button"
+          class="block w-full text-left"
+          label="Restore Form"
+          @click="restoreForm"
+        />
+        <D9MenuLink
+          as="button"
+          type="button"
+          class="block w-full text-left"
+          label="Delete forever"
+          @click="deleteForever"
+        />
+      </D9Menu>
       <a
+        v-if="!form.is_trashed"
         :href="route('forms.edit', form.uuid)"
         class="flex cursor-pointer items-center justify-end transition duration-150 hover:text-blue-600 group-hover:scale-110"
       >
@@ -115,7 +150,7 @@
 </template>
 
 <script setup lang="ts">
-import { D9Icon, D9Menu, D9MenuLink } from "@deck9/ui";
+import { D9Icon, D9Menu, D9MenuLink, D9Button } from "@deck9/ui";
 import { ref } from "vue";
 import { onClickOutside } from "@vueuse/core";
 import { callDuplicateForm } from "@/api/forms";
@@ -154,5 +189,15 @@ const duplicateForm = async () => {
   window.location.href = window.route("forms.edit", {
     uuid: newFormResponse.data.uuid,
   });
+};
+
+const restoreForm = () => {
+  window.alert("restore form now");
+};
+
+const deleteForever = () => {
+  window.confirm(
+    "Are you sure you want to delete your form permanently. This action cannot be undone."
+  );
 };
 </script>

--- a/resources/js/components/Dashboard/FormListItem.vue
+++ b/resources/js/components/Dashboard/FormListItem.vue
@@ -229,7 +229,7 @@ const publishForm = async () => {
 };
 
 const unpublishForm = async () => {
-  await callUnpublishForm(props.form)
+  await callUnpublishForm(props.form);
 
   window.location.reload();
 };
@@ -243,9 +243,7 @@ const restoreForm = async () => {
 };
 
 const deleteForm = async () => {
-  window.confirm(
-    "Are you sure you want to delete your form?"
-  );
+  window.confirm("Are you sure you want to delete your form?");
 
   await callDeleteForm(props.form);
 

--- a/resources/js/types/models.d.ts
+++ b/resources/js/types/models.d.ts
@@ -47,6 +47,7 @@ interface FormModel extends BaseModel {
     completed_sessions: number;
     completion_rate: number;
     is_published: boolean;
+    is_trashed: boolean;
     initials: string | null;
     published_at: string | null;
     deleted_at: string | null;

--- a/resources/js/types/models.d.ts
+++ b/resources/js/types/models.d.ts
@@ -242,3 +242,5 @@ type EmbedFlags = {
 };
 
 type ImageType = "avatar" | "background";
+
+type FilterSetting = "published" | "unpublished" | "trashed" | null;

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Api\GetFormStoryboardController;
 use App\Http\Controllers\Api\PublishFormController;
 use App\Http\Controllers\Api\PurgeFormSubmissionsController;
 use App\Http\Controllers\Api\ShowFormController;
+use App\Http\Controllers\Api\TrashedFormController;
 use App\Http\Controllers\Api\UnpublishFormController;
 use App\Http\Controllers\Api\ZiggyController;
 use Illuminate\Http\Request;
@@ -54,6 +55,9 @@ $router->middleware(['auth:sanctum'])->group(function (Router $router) {
     $router->get('forms/{form}', [FormController::class, 'show'])->name('api.forms.show');
     $router->post('forms/{form}', [FormController::class, 'update'])->name('api.forms.update');
     $router->delete('forms/{form}', [FormController::class, 'delete'])->name('api.forms.delete');
+
+    $router->delete('forms/trashed/{form}', [TrashedFormController::class, 'delete'])->name('api.forms.trashed.delete');
+    $router->post('forms/trashed/{form}/restore', [TrashedFormController::class, 'restore'])->name('api.forms.trashed.restore');
 
     // Form Duplication
     $router->post('forms/{form}/duplicate', DuplicateFormController::class)->name('api.forms.duplicate');

--- a/tests/Feature/FormSubmissionNotificationTest.php
+++ b/tests/Feature/FormSubmissionNotificationTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests\Feature;
 
-use Mail;
+use App\Mail\FormSubmissionNotification;
 use App\Models\Form;
 use App\Models\FormSession;
-use App\Mail\FormSubmissionNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mail;
 
 uses(RefreshDatabase::class);
 
-it("can activate notifications for form submissions", function () {
+it('can activate notifications for form submissions', function () {
     $form = Form::factory()->create();
 
     $updateRequestA = [
@@ -36,8 +36,7 @@ it("can activate notifications for form submissions", function () {
     $this->assertNotTrue($form->is_notification_via_mail);
 });
 
-
-it("send an email notification for a submitted form", function () {
+it('send an email notification for a submitted form', function () {
     Mail::fake();
 
     $form = Form::factory()->create([

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -243,6 +243,16 @@ test('can_delete_a_form', function () {
     $this->assertNotNull($form->fresh()->deleted_at);
 });
 
+test('a user can permanently delete a form', function () {
+    $form = Form::factory()->create();
+
+    $this->actingAs($form->user)
+        ->json('DELETE', route('api.forms.trashed.delete', $form->uuid))
+        ->assertStatus(200);
+
+    $this->assertNull(Form::withTrashed()->find($form->id));
+});
+
 test('can_enable_or_disable_email_notifications_for_a_form', function () {
     $form = Form::factory()->create();
 

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -51,6 +51,34 @@ test('a_user_can_return_all_the_forms_in_his_account', function () {
     $this->assertEquals($form->uuid, $response->json()[0]['uuid']);
 });
 
+test('a user can filter for published/unpublished/trashed forms', function () {
+    $user = User::factory()->create();
+
+    // published form
+    $formA = Form::factory()->for($user)->create();
+
+    // unpublished form
+    $formB = Form::factory()->unpublished()->for($user)->create();
+
+    // deleted form
+    $formC = Form::factory()->deleted()->for($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('api.forms.index', ['filter' => 'published']))
+        ->assertStatus(200)
+        ->assertJsonFragment(['uuid' => $formA->uuid]);
+
+    $this->actingAs($user)
+        ->get(route('api.forms.index', ['filter' => 'unpublished']))
+        ->assertStatus(200)
+        ->assertJsonFragment(['uuid' => $formB->uuid]);
+
+    $this->actingAs($user)
+        ->get(route('api.forms.index', ['filter' => 'trashed']))
+        ->assertStatus(200)
+        ->assertJsonFragment(['uuid' => $formC->uuid]);
+});
+
 test('a_user_cannot_return_forms_in_other_accounts', function () {
     /** @var User $user */
     $user = User::factory()->create();


### PR DESCRIPTION
closes to #94 

This is a first improvement for the forms dashboard. Right now we do not have any possibilites to filter or search for specific forms.

This PR adds a very basic filter machanic, which allows a user to show only `published`, `unpublished` or `trashed` forms.

I also added some context menu actions that lets a user delete, publish or unpublish a form without leaving the dashboard.

This should make dashboard a bit more usable if you have a lot of forms, but it is also just the foundation for adding more filter settings.