### PR TITLE
Fix docker configuration example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,29 @@ docker volume create input-data
 # Run the container using port 8080 on the host
 docker run -d -p 8080:8080 --name input \
     -v input-data:/var/www/html/storage \
+    -e APP_URL=https://hostname.domain.tld:8080 \
     ghcr.io/deck9/input:main
+```
+
+or as `docker-compose.yml`:
+
+```docker-compose
+version: '3.2'
+services:
+    input:
+      image: ghcr.io/deck9/input:main
+      container_name: input
+      hostname: <hostname>
+      volumes:
+        - input-data:/var/www/html/storage
+      ports:
+        - 8080:8080
+      restart: unless-stopped
+      environment:
+        - APP_URL="https://<hostname>:8080"
+
+volumes:
+  input-data:
 ```
 
 ### Behind a Proxy


### PR DESCRIPTION
According to #134 the environment variable `APP-URL` needs to be set for the container even when not running behind a proxy, to allow the authentication cookie to be set correctly. I added this and also a `docker-compose.yml` configuration example to the `README.md`.